### PR TITLE
fix(FunctionTypeAnnotation): add enclosing parens

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -503,7 +503,7 @@ function getTypeAnnotationString(annotation) {
     case 'FunctionTypeAnnotation':
       const params = annotation.params.map(getFunctionTypeAnnotationParameter).join(', ');
       const returnType = getTypeAnnotationString(annotation.returnType);
-      return `(${params}) => ${returnType}`;
+      return `((${params}) => ${returnType})`;
 
     case 'ArrayTypeAnnotation':
       const elementType = getTypeAnnotationString(annotation.elementType);


### PR DESCRIPTION
fixes typescript compiler issues when parens get removed for union types ref #17 and aurelia/router#145

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/yolodev/babel-dts-generator/18)

<!-- Reviewable:end -->
