### PR TITLE
feat(dts): make any 'any' optional

### DIFF
--- a/src/generators/dts.js
+++ b/src/generators/dts.js
@@ -538,7 +538,7 @@ function getFunctionTypeAnnotationParameter(node) {
   const { name: { name }, typeAnnotation, optional } = node;
   const type = getTypeAnnotationString(typeAnnotation, 'any');
 
-  return `${name}${optional ? '?' : ''}: ${type}`;
+  return `${name}${(optional || type === 'any') ? '?' : ''}: ${type}`;
 }
 
 function getFunctionTypeAnnotationParameterNode(node) {


### PR DESCRIPTION
currently 
`function(optionalParameter)` is interpreted as `function(optionalParameter: any)`
since nothing is known about the optionalParameter, it might have been optional and if it is, the resulting d.ts isn't working (as it is for our spoonx plugins). 
thus, i suggest, to treat any unknown parameter as optional. so:
`function(optionalParameter)` is interpreted as `function(optionalParameter?: any)`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yolodev/babel-dts-generator/40)

<!-- Reviewable:end -->
