### PR TITLE
add support for: suppress ambient declaration option

### DIFF
--- a/src/generators/ast.js
+++ b/src/generators/ast.js
@@ -95,8 +95,8 @@ class ExportAllFromNode extends Node {
     this._source = source;
   }
 
-  _toCode(ctx) {
-    return `export${ctx.suppressAmbientDeclaration ? ' declare' : ''} * from '${this._source}';`;
+  _toCode() {
+    return `export * from '${this._source}';`;
   }
 }
 

--- a/src/generators/index.js
+++ b/src/generators/index.js
@@ -10,14 +10,15 @@ export function generate({
     root,
     suppressModulePath,
     suppressComments,
-    markUnspecifiedAsOptional
+    markUnspecifiedAsOptional,
+    suppressAmbientDeclaration
   }, fileMeta) {
   const nodes = moduleImports.concat(interfaces, moduleExports).filter(id);
 
   const module = createModuleDeclaration(suppressModulePath ? root : moduleId, nodes);
 
   fileMeta.dts = module;
-  return module.toString({ suppressComments, markUnspecifiedAsOptional });
+  return module.toString({ suppressComments, markUnspecifiedAsOptional, suppressAmbientDeclaration });
 }
 
 export function createNodeGenerator({ root }) {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -90,7 +90,8 @@ export function plugin({ types: t }) { // eslint-disable-line
         ignoreEmptyInterfaces = true,
         ignoreEmptyClasses = false,
         dryRun = false,
-        markUnspecifiedAsOptional = true
+        markUnspecifiedAsOptional = true,
+        suppressAmbientDeclaration = true
       } = opts;
 
       const moduleId = `${packageName}/${relative(moduleRoot, filename).replace('.js', '')}`;
@@ -108,6 +109,7 @@ export function plugin({ types: t }) { // eslint-disable-line
       meta.ignoreEmptyClasses = ignoreEmptyClasses;
       meta.dryRun = dryRun;
       meta.markUnspecifiedAsOptional = markUnspecifiedAsOptional;
+      meta.suppressAmbientDeclaration = suppressAmbientDeclaration;
       meta.nodeGenerator = createNodeGenerator(meta);
 
       file.metadata[symb] = meta;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -91,7 +91,7 @@ export function plugin({ types: t }) { // eslint-disable-line
         ignoreEmptyClasses = false,
         dryRun = false,
         markUnspecifiedAsOptional = true,
-        suppressAmbientDeclaration = true
+        suppressAmbientDeclaration = false
       } = opts;
 
       const moduleId = `${packageName}/${relative(moduleRoot, filename).replace('.js', '')}`;

--- a/test/index.js
+++ b/test/index.js
@@ -30,6 +30,7 @@ function normalize(str) {
 function run(files, index, errors) {
   const file = files[index];
   const expectedFile = file.replace('.src.js', '.expected.ts');
+  const suppressAmbientDeclaration = false;
   return exists(expectedFile).then(fileExists => {
     if (!fileExists) {
       console.error(`File ${expectedFile} does not exist.`);
@@ -58,7 +59,8 @@ function run(files, index, errors) {
             packageName: 'spec',
             typings: '',
             suppressModulePath: true,
-            suppressComments: false
+            suppressComments: false,
+            suppressAmbientDeclaration: suppressAmbientDeclaration
           }],
           'transform-decorators-legacy'
         ]
@@ -78,7 +80,11 @@ function run(files, index, errors) {
             actual = normalize(actual);
 
             expected = expected.trim();
-            actual = actual.split('\n').slice(1, -1).map(l => l.substring(2)/* remove leading whitespace */).join('\n').trim();
+            if (!suppressAmbientDeclaration) {
+              actual = actual.split('\n').slice(1, -1).map(l => l.substring(2)/* remove leading whitespace */).join('\n').trim();
+            } else {
+              actual = actual.replace(/export declare/g, 'export').trim();
+            }
 
             const diff = diffLines(expected, actual, { ignoreWhitespace: true });
             if (diff.length > 1 || diff[0].removed) {


### PR DESCRIPTION
this option (when true) will generate .d.ts files that are compatible with [npm package typings](https://www.typescriptlang.org/docs/handbook/typings-for-npm-packages.html)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yolodev/babel-dts-generator/46)

<!-- Reviewable:end -->
