### PR TITLE
Add basic support for object type annotations

### DIFF
--- a/spec/types/object-literal-types.expected.ts
+++ b/spec/types/object-literal-types.expected.ts
@@ -1,0 +1,3 @@
+export const zero: {};
+export const foo: { [key: string]: number };
+export const bar: { foo: number };

--- a/spec/types/object-literal-types.src.js
+++ b/spec/types/object-literal-types.src.js
@@ -1,0 +1,3 @@
+export const zero : {} = null;
+export const foo: { [key: string]: number } = null;
+export const bar: { foo: number } = null;

--- a/src/generators/dts.js
+++ b/src/generators/dts.js
@@ -543,6 +543,28 @@ function getTypeAnnotationString(annotation, defaultType = 'any') {
       const elements = annotation.types.map(getTypeAnnotationString).join(', ');
       return `[${elements}]`;
 
+    case 'ObjectTypeAnnotation':
+      const { properties, indexers } = annotation;
+      const annotations =
+        properties.map(({ key: { name }, value }) => {
+          const valueType = getTypeAnnotationString(value);
+
+          return `${name}: ${valueType}`;
+        }).concat(indexers.map(({ id: { name }, key, value }) => {
+          const keyType = getTypeAnnotationString(key);
+          const valueType = getTypeAnnotationString(value);
+
+          return `[${name}: ${keyType}]: ${valueType}`;
+        }));
+
+      if (annotations.length === 0) {
+        return '{}';
+      }
+
+      const annotationsString = annotations.join(', ');
+
+      return `{ ${annotationsString} }`;
+
     default: throw new Error(`Unsupported type annotation type: ${annotation.type}`);
   }
 }


### PR DESCRIPTION
Support object type annotations like

  export const foo: { [key: string]: number };

and

  export const bar: { foo: number };

Resolves: #48

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yolodev/babel-dts-generator/50)

<!-- Reviewable:end -->
