### PR TITLE
Add support for this type-annotations

### DIFF
--- a/spec/class/method.expected.ts
+++ b/spec/class/method.expected.ts
@@ -2,6 +2,7 @@ export class Foo {
   constructor();
   foo(): number;
   bat(a?: number): number;
+  self(): this;
   optional(param?: any): any;
   'bar-baz'(): any;
   'foo-bar'(): any;

--- a/spec/class/method.src.js
+++ b/spec/class/method.src.js
@@ -13,6 +13,10 @@ export class Foo {
 
   }
 
+  self(): this {
+
+  }
+
   optional(param) {
 
   }

--- a/src/generators/dts.js
+++ b/src/generators/dts.js
@@ -527,6 +527,9 @@ function getTypeAnnotationString(annotation, defaultType = 'any') {
     case 'BooleanTypeAnnotation':
       return 'boolean';
 
+    case 'ThisTypeAnnotation':
+      return 'this';
+
     case 'UnionTypeAnnotation':
       return annotation.types.map(getTypeAnnotationString).join(' | ');
 


### PR DESCRIPTION
This update adds support for methods returning typeof this.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yolodev/babel-dts-generator/55)

<!-- Reviewable:end -->
