### PR TITLE
Add support for typeof type annotations

### DIFF
--- a/spec/class/method.expected.ts
+++ b/spec/class/method.expected.ts
@@ -6,4 +6,5 @@ export class Foo {
   'bar-baz'(): any;
   'foo-bar'(): any;
   [s](): any;
+  static alias(): typeof Foo;
 }

--- a/spec/class/method.src.js
+++ b/spec/class/method.src.js
@@ -28,4 +28,8 @@ export class Foo {
   [s]() {
 
   }
+
+  static alias(): typeof Foo {
+
+  }
 }

--- a/src/generators/dts.js
+++ b/src/generators/dts.js
@@ -530,6 +530,10 @@ function getTypeAnnotationString(annotation, defaultType = 'any') {
     case 'UnionTypeAnnotation':
       return annotation.types.map(getTypeAnnotationString).join(' | ');
 
+    case 'TypeofTypeAnnotation':
+      const argument = getTypeAnnotationString(annotation.argument);
+      return `typeof ${argument}`;
+
     case 'FunctionTypeAnnotation':
       const params = annotation.params.map(getFunctionTypeAnnotationParameter).join(', ');
       const returnType = getTypeAnnotationString(annotation.returnType);


### PR DESCRIPTION
This update adds support for writing methods that return class
factories etc. by relying on the typeof annotation.

Closes #54

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yolodev/babel-dts-generator/56)

<!-- Reviewable:end -->
